### PR TITLE
Fix folder rendering

### DIFF
--- a/components/shape/components/index.js
+++ b/components/shape/components/index.js
@@ -42,7 +42,7 @@ const ShapeComponents = ({ components, overrides }) => {
         );
       }
 
-      if (type === 'richText') {
+      if (type === 'richText' && component.content.json) {
         Component = Component || CrystallizeContent;
         return <Component key={key} {...component.content.json[0]} />;
       }


### PR DESCRIPTION
`component.content.json` can be null, which can cause rich text content to throw an error on a page.

![](https://media1.giphy.com/media/a7jQRlJDCjSmI/giphy.gif)