### PR TITLE
Fix an issue with calling unstable_revalidate

### DIFF
--- a/src/pages/[...catalogue].js
+++ b/src/pages/[...catalogue].js
@@ -75,7 +75,7 @@ export async function getStaticProps({ params, preview }) {
         ...data,
         type
       },
-      unstable_revalidate: 1
+      revalidate: 1
     };
   } catch (error) {
     console.warn(`Could not get data for ${asPath}`);
@@ -83,7 +83,7 @@ export async function getStaticProps({ params, preview }) {
 
   return {
     props: {},
-    unstable_revalidate: 1
+    revalidate: 1
   };
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ export async function getStaticProps({ params = {}, preview }) {
     props: {
       ...data
     },
-    unstable_revalidate: 1
+    revalidate: 1
   };
 }
 


### PR DESCRIPTION
Fixes the following error by replacing `unstable_revalidate` with `revalidate`:

```
Error: The `unstable_revalidate` property is available for general use.
Please use `revalidate` instead.
```