### PR TITLE
fix: move meta tags out of _document

### DIFF
--- a/src/components/head/meta-tags.js
+++ b/src/components/head/meta-tags.js
@@ -1,0 +1,21 @@
+import Head from 'next/head';
+
+const MetaTags = () => {
+  return (
+    <Head>
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, minimal-ui"
+      />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@700&family=Roboto:wght@300;400;700&display=swap"
+        rel="stylesheet"
+      />
+
+      <meta name="theme-color" content="#ffffff" />
+    </Head>
+  );
+};
+
+export default MetaTags;

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,3 +1,4 @@
+import MetaTags from 'components/head/meta-tags';
 import { AuthProvider } from 'components/auth-context';
 import { SettingsProvider } from 'components/settings-context';
 import { BasketProvider } from 'components/basket';
@@ -8,18 +9,21 @@ import { I18nextProvider } from 'lib/i18n';
 function MyApp({ Component, pageProps, commonData }) {
   const { tenant, mainNavigation, locale, localeResource } = commonData;
   return (
-    <I18nextProvider locale={locale} localeResource={localeResource}>
-      <SettingsProvider
-        currency={tenant.defaults.currency}
-        mainNavigation={mainNavigation}
-      >
-        <AuthProvider>
-          <BasketProvider>
-            <Component {...pageProps} />
-          </BasketProvider>
-        </AuthProvider>
-      </SettingsProvider>
-    </I18nextProvider>
+    <>
+      <MetaTags />
+      <I18nextProvider locale={locale} localeResource={localeResource}>
+        <SettingsProvider
+          currency={tenant.defaults.currency}
+          mainNavigation={mainNavigation}
+        >
+          <AuthProvider>
+            <BasketProvider>
+              <Component {...pageProps} />
+            </BasketProvider>
+          </AuthProvider>
+        </SettingsProvider>
+      </I18nextProvider>
+    </>
   );
 }
 

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -37,17 +37,6 @@ export default class MyDocument extends Document {
     return (
       <html lang={this.props.locale.appLanguage}>
         <Head>
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, minimal-ui"
-          />
-          <meta name="apple-mobile-web-app-capable" content="yes" />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@700&family=Roboto:wght@300;400;700&display=swap"
-            rel="stylesheet"
-          />
-
-          <meta name="theme-color" content="#ffffff" />
           <link rel="icon" href="/static/favicon.svg" />
           <link rel="mask-icon" href="/static/mask-icon.svg" color="#5bbad5" />
           <link rel="apple-touch-icon" href="/static/apple-touch-icon.png" />


### PR DESCRIPTION
Related to: https://github.com/vercel/next.js/blob/master/errors/no-document-viewport-meta.md

Putting meta tags inside `_document` can lead to issues like: https://github.com/vercel/next.js/issues/13230