### PR TITLE
Quantity of more than 1 on a product is now possible with Klarna Checkout

### DIFF
--- a/src/pages/api/payment-providers/klarna/render-checkout.js
+++ b/src/pages/api/payment-providers/klarna/render-checkout.js
@@ -6,7 +6,8 @@ function orderToKlarnaCart(lineItems) {
   let order_amount = 0;
 
   const order_lines = lineItems.map((item) => {
-    order_tax_amount += item.product_tax_amount * 100;
+    let item_tax_amount = item.product_tax_amount * 100 * item.quantity;
+    order_tax_amount += item_tax_amount;
 
     // Klarna represents numbers as number * 100
     // Ex: 11.59 becomes 1159. 9 becomes 900
@@ -27,7 +28,7 @@ function orderToKlarnaCart(lineItems) {
       }),
       image_url: item.image_url,
       total_amount: amount,
-      total_tax_amount: item.product_tax_amount * 100
+      total_tax_amount: item_tax_amount
     };
   });
 


### PR DESCRIPTION
Tax amount for an order line was calculated as if the quantity was always 1.
Adding 2 or more products of the same kind made Klarna Checkout crash upon render.